### PR TITLE
[PR] Change VALS Center Admin capabilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,12 +6,33 @@ A WordPress plugin that provides custom roles for the VALS Program site
 
 ## Provided Roles
 
-* **VALS Registered Trainee** - Users with this role have `read` capabilities and can view only their profile (any other admin pages redirect). They can be assigned to a VALS Center.
-* **VALS Certified** - Users with this role have the same capabilities and access levels as VALS Registered Trainees. They can be assigned a Certification Date and to a VALS Center.
-* **VALS Center Admin** - Users with this role have `read`, `list_users`, and `promote_users` capabilities. They can be assigned to a VALS Center, and when viewing the Users list, they can see only users assigned to the same VALS Center and one of the provided roles. They can only promote users to one of the other two provided roles.
+### VALS Center Admin
+Users with this role have `read`, `list_users`, and `create_users` capabilities. They can:
+* (and should) be assigned to a VALS Center;
+* add new users, who will be:
+  * associated with the VALS Center Admin's respective VALS Center; and
+  * assigned the VALS Registered Trainee role;
+* view the Users list, but can only see users who are:
+  * associated with the VALS Center Admin's respective VALS Center; and
+  * assigned to one of the roles listed here.
+
+### VALS Certified
+Users with this role have `read` capabilities. They can:
+* be assigned to a VALS Center;
+* be assigned a Certification Date;
+* view only their own profile.
+
+When a user's role is changed to VALS Certified, the current date is automatically assigned as the user's Certification Date (which can be manually adjusted if needed).
+
+### VALS Registered Trainee
+Users with this role have `read` capabilities. They can:
+* be assigned to a VALS Center;
+* view only their own profile.
 
 ## Other Features
 
+A custom taxonomy is provided for associating users with a VALS Center.
+
 A stylesheet that hides a majority of the default interface is enqueued for profile pages belonging to users with any of the provided roles. The *First Name*, *Last Name*, and *Account Management* fields are left available.
 
-The plugin also adds *Date Certified* and *Center* columns to the Users list. In both the *Date Certified* column and in *VALS Certified* users profiles, the certification date is displayed in orange text when it is within 6 months of expiring, and in red text if it has expired.
+*Date Certified* and *Center* columns are added to the Users list. In both the *Date Certified* column and in *VALS Certified* users profiles, the certification date is displayed in orange text when it is within 6 months of expiring, and in red text if it has expired.

--- a/css/add-user.css
+++ b/css/add-user.css
@@ -1,0 +1,4 @@
+#ajax-response + p,
+#adduser {
+	display: none;
+}

--- a/includes/class-wsuwp-vals-custom-roles.php
+++ b/includes/class-wsuwp-vals-custom-roles.php
@@ -66,6 +66,7 @@ class WSUWP_VALS_Custom_Roles {
 		add_action( 'pre_get_users', array( $this, 'vals_pre_user_query' ) );
 		add_filter( 'views_users', array( $this, 'vals_center_admin_views_users' ) );
 		add_filter( 'editable_roles', array( $this, 'vals_center_admin_editable_roles' ) );
+		add_action( 'user_register', array( $this, 'save_new_user_center' ) );
 	}
 
 	/**
@@ -620,5 +621,21 @@ class WSUWP_VALS_Custom_Roles {
 		}
 
 		return $all_roles;
+	}
+
+	/**
+	 * Associate new users added by a VALS Center Admin with the respective VALS Center.
+	 *
+	 * @since 0.0.2
+	 *
+	 * @param int $user_id The ID of the new user.
+	 */
+	public function save_new_user_center( $user_id ) {
+		$current_user = wp_get_current_user();
+
+		if ( $this->vals_admin_role( $current_user ) ) {
+			$center = wp_get_object_terms( $current_user->ID, $this->taxonomy_slug );
+			wp_set_object_terms( $user_id, array( $center[0]->slug ), $this->taxonomy_slug, false );
+		}
 	}
 }

--- a/includes/class-wsuwp-vals-custom-roles.php
+++ b/includes/class-wsuwp-vals-custom-roles.php
@@ -67,6 +67,7 @@ class WSUWP_VALS_Custom_Roles {
 		add_filter( 'views_users', array( $this, 'vals_center_admin_views_users' ) );
 		add_filter( 'editable_roles', array( $this, 'vals_center_admin_editable_roles' ) );
 		add_action( 'user_register', array( $this, 'save_new_user_center' ) );
+		add_action( 'set_user_role', array( $this, 'add_certification_date' ), 10, 2 );
 	}
 
 	/**
@@ -655,6 +656,21 @@ class WSUWP_VALS_Custom_Roles {
 		if ( $this->vals_admin_role( $current_user ) ) {
 			$center = wp_get_object_terms( $current_user->ID, $this->taxonomy_slug );
 			wp_set_object_terms( $user_id, array( $center[0]->slug ), $this->taxonomy_slug, false );
+		}
+	}
+
+	/**
+	 * Set the Certification Date when a user's role is changed to 'VALS Certified'.
+	 *
+	 * @since 0.0.2
+	 *
+	 * @param int    $user_id The user ID.
+	 * @param string $role    The user's new role.
+	 */
+	public function add_certification_date( $user_id, $role ) {
+		if ( $this->roles['certified'] === $role ) {
+			// Use today's date. (This can be manually changed by editing the user, if needed.)
+			update_user_meta( $user_id, 'certification', sanitize_text_field( date( 'Y-m-d' ) ) );
 		}
 	}
 }

--- a/includes/class-wsuwp-vals-custom-roles.php
+++ b/includes/class-wsuwp-vals-custom-roles.php
@@ -508,23 +508,31 @@ class WSUWP_VALS_Custom_Roles {
 	}
 
 	/**
-	 * Enqueue a stylesheet for profiles of users with a custom VALS role.
+	 * Enqueue stylesheets on certain dashboard pages for users with a custom VALS role.
 	 *
 	 * @since 0.0.1
 	 *
 	 * @param string $hook_suffix The current admin page.
 	 */
 	public function vals_roles_enqueue_scripts( $hook_suffix ) {
-		if ( ! in_array( $hook_suffix, array( 'profile.php', 'user-edit.php' ), true ) ) {
-			return;
+		// Hide a majority of the default profile fields of/for users with a custom VALS role.
+		if ( in_array( $hook_suffix, array( 'profile.php', 'user-edit.php' ), true ) ) {
+			global $user_id;
+
+			$user = get_userdata( $user_id );
+
+			if ( array_intersect( $this->roles, (array) $user->roles ) ) {
+				wp_enqueue_style( 'vals-role-profile', plugins_url( 'css/vals-role-profile.css', dirname( __FILE__ ) ) );
+			}
 		}
 
-		global $user_id;
+		// Hide the "Add Existing User" form from VALS Center Admins.
+		if ( 'user-new.php' === $hook_suffix ) {
+			$current_user = wp_get_current_user();
 
-		$user = get_userdata( $user_id );
-
-		if ( array_intersect( $this->roles, (array) $user->roles ) ) {
-			wp_enqueue_style( 'vals-role-profile', plugins_url( 'css/vals-role-profile.css', dirname( __FILE__ ) ) );
+			if ( $this->vals_admin_role( $current_user ) ) {
+				wp_enqueue_style( 'vals-role-profile', plugins_url( 'css/add-user.css', dirname( __FILE__ ) ) );
+			}
 		}
 	}
 

--- a/includes/class-wsuwp-vals-custom-roles.php
+++ b/includes/class-wsuwp-vals-custom-roles.php
@@ -96,7 +96,7 @@ class WSUWP_VALS_Custom_Roles {
 			array(
 				'read' => true,
 				'list_users' => true,
-				'promote_users' => true,
+				'create_users' => true,
 			)
 		);
 	}
@@ -505,12 +505,6 @@ class WSUWP_VALS_Custom_Roles {
 		if ( $this->non_admin_role( $user ) ) {
 			remove_menu_page( 'index.php' );
 		}
-
-		// Remove the 'Users' > 'Add New' link for users with the 'VALS Center Admin' role.
-		// (Access to this is granted via the `promote_users` capability.)
-		if ( $this->vals_admin_role( $user ) ) {
-			remove_submenu_page( 'users.php', 'user-new.php' );
-		}
 	}
 
 	/**
@@ -614,6 +608,7 @@ class WSUWP_VALS_Custom_Roles {
 			unset( $all_roles['author'] );
 			unset( $all_roles['editor'] );
 			unset( $all_roles['vals_center_admin'] );
+			unset( $all_roles['vals_certified'] );
 		}
 
 		return $all_roles;


### PR DESCRIPTION
This makes the following requested changes:

* Remove the VALS Center Admin role's capability to promote users;
* Allow VALS Center Admins to add new users;
  * They should only be able assign the 'VALS Registered Trainee' role to new users;
  * The user should be associated with the same VALS Center as the Admin who added them;
* Only allow VALS Center Admins to access some of the 'Users'-related pages in the Dashboard;
* Automatically set the 'Certification Date' meta as the current date when a user's role is changed to 'VALS Certified'.

